### PR TITLE
Type cast result variable to string

### DIFF
--- a/Model/Config/Source/StoreLang.php
+++ b/Model/Config/Source/StoreLang.php
@@ -114,7 +114,7 @@ class StoreLang
 
     private function getCustomHreflangTagForStore($storeId)
     {
-        $result = $this->scopeConfig->getValue(
+        $result = (string) $this->scopeConfig->getValue(
             'oe_hreflang/general/custom_hreflang_tag',
             ScopeInterface::SCOPE_STORE,
             $storeId


### PR DESCRIPTION
Hi,

Tiny change. The explode function on [L123](https://github.com/outeredge/magento-hreflang-alternateurl-module/blob/master/Model/Config/Source/StoreLang.php#L123) can throw a deprecation warning in PHP 8.1.

```
Deprecated Functionality: explode(): Passing null to parameter #2 ($string) of type string is deprecated in vendor/outeredge/magento-hreflang-alternateurl-module/Model/Config/Source/StoreLang.php on line 123
```